### PR TITLE
Support for Custom Optimism Bedrock rollups

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,27 @@ Extractor Client for ethereum. Uses the fetch API in order to trigger RPC reques
 
 ## OptimismExtractoorClient
 Extractoor Client for Optimism Bedrock. Exposes method for generating the output root data for a given L1 block by number - `generateLatestOutputData`. 
-**IMPORTANT: Optimism Bedrock is still only on goerli and the `OptimismExtractoorClient` uses the currently available addresses based on goerli. When Bedrock goes mainnet these will be changed and moved into config.**
+Instantiating the client can be as simple as:
+```
+import { OptimismExtractoorClient, BASE_GOERLI_CONFIG } from 'extractoor'
 
+const fetcher = new OptimismExtractoorClient({YourL2RPC}, {YourL1RPC}, {YourConfig});
+// const fetcher = new OptimismExtractoorClient(process.env.BASE_GOERLI_RPC_URL, process.env.GOERLI_RPC_URL, BASE_GOERLI_CONFIG);
+```
+
+Two default configs are available at te moment `OPTIMISM_GOERLI_CONFIG` and `BASE_GOERLI_CONFIG`. You can connect to a another OptimismBedrock rollup by providing config conforming to the `OptimismNetworkConfig` interface. Example:
+
+```
+import { OptimismExtractoorClient, OptimismNetworkConfig } from 'extractoor'
+
+const customConfig: OptimismNetworkConfig =  = {
+    L2WithdrawalContractAddress: "0x4200000000000000000000000000000000000016",
+    OutputOracleAddress: "0xE6Dfba0953616Bacab0c9A8ecb3a9BBa77FC15c0",
+    OutputOracleL2OutputPosition: 3
+}
+
+const fetcher = new OptimismExtractoorClient(process.env.CUSTOM_BEDROCK_RPC, process.env.L1_RPC, customConfig);
+```
 # Contributing
 Pull requests welcome. The project is built via `tsdx`. In order to run the compilation in watch mode use 
 ```
@@ -35,7 +54,7 @@ Various runnable examples can be found in the `example` directory. Refer to its 
 ## Getting the necessary data for OptimismInbox message receive
 ```
 import { BN, bufferToHex, keccak, setLengthLeft, toBuffer, unpadBuffer } from 'ethereumjs-util'
-import { MPTProofsEncoder, OptimismExtractoorClient } from 'extractoor'
+import { MPTProofsEncoder, OptimismExtractoorClient, OPTIMISM_GOERLI_CONFIG } from 'extractoor'
 const dotenv = require('dotenv');
 dotenv.config()
 
@@ -52,7 +71,7 @@ const indexBN = new BN(indexInTheArray);
 const slotBN = arrayDefinitionBN.add(indexBN);
 const slot = `0x${slotBN.toString("hex")}`
 
-const fetcher = new OptimismExtractoorClient(process.env.OPTIMISM_GOERLI_RPC_URL || "", process.env.GOERLI_RPC_URL || "");
+const fetcher = new OptimismExtractoorClient(process.env.OPTIMISM_GOERLI_RPC_URL, process.env.GOERLI_RPC_URL, OPTIMISM_GOERLI_CONFIG);
 
 // Step 2 - Get all the information needed for the Optimism Output Root inclusion inside L1 proof
 const output = await fetcher.generateLatestOutputData(`0x${blockNum.toString(16)}`);

--- a/example/get-ethereum-proof-for-array.ts
+++ b/example/get-ethereum-proof-for-array.ts
@@ -1,10 +1,10 @@
 import { BN, keccak, setLengthLeft, toBuffer } from 'ethereumjs-util';
-import { OptimismExtractoorClient } from 'extractoor'
+import { OptimismExtractoorClient, OPTIMISM_GOERLI_CONFIG } from './../src'
 const dotenv = require('dotenv');
 dotenv.config()
 
 async function run() {
-    const fetcher = new OptimismExtractoorClient(process.env.OPTIMISM_GOERLI_RPC_URL || "", process.env.GOERLI_RPC_URL || "");
+    const fetcher = new OptimismExtractoorClient(process.env.OPTIMISM_GOERLI_RPC_URL || "", process.env.GOERLI_RPC_URL || "", OPTIMISM_GOERLI_CONFIG);
 
     const arrayDefinitionPosition = 0; // Definition position of the array inside the solidity contract
     const indexInTheArray = 0; // The index of the element you are looking for

--- a/example/get-ethereum-proof.ts
+++ b/example/get-ethereum-proof.ts
@@ -1,9 +1,9 @@
-import { OptimismExtractoorClient } from 'extractoor'
+import { OptimismExtractoorClient, OPTIMISM_GOERLI_CONFIG } from './../src'
 const dotenv = require('dotenv');
 dotenv.config()
 
 async function run() {
-    const fetcher = new OptimismExtractoorClient(process.env.OPTIMISM_GOERLI_RPC_URL || "", process.env.GOERLI_RPC_URL || "");
+    const fetcher = new OptimismExtractoorClient(process.env.OPTIMISM_GOERLI_RPC_URL || "", process.env.GOERLI_RPC_URL || "", OPTIMISM_GOERLI_CONFIG);
 
     const block = 5737708;
     const res = await fetcher.optimism.getProof("0xcA7B05255F52C700AE25C278DdB03C02459F7AE8", "0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563", `0x${block.toString(16)}`);

--- a/example/get-extractoor-optimism-data.ts
+++ b/example/get-extractoor-optimism-data.ts
@@ -1,15 +1,14 @@
 import { BN, bufferToHex, keccak, setLengthLeft, toBuffer, unpadBuffer } from 'ethereumjs-util'
-import { MPTProofsEncoder, OptimismExtractoorClient } from 'extractoor'
-import { } from 'extractoor'
+import { MPTProofsEncoder, OptimismExtractoorClient, OPTIMISM_GOERLI_CONFIG } from './../src'
 const dotenv = require('dotenv');
 dotenv.config()
 
 async function run() {
 
     // Inputs
-    const blockNum = 8529353; // The L1 block number we will be proving contains the Optimism state
     const targetAccount = "0xcA7B05255F52C700AE25C278DdB03C02459F7AE8"; // The account inside Optimism we are proving for
     const arrayDefinitionPosition = 0; // Definition position of the array inside the solidity contract
+    const blockNum = 8529353; // The L1 block number we will be proving contains the Optimism state
     const indexInTheArray = 1; // The index of the element you are looking for
 
     // Step 1 - Derive the storage slot from the array definition and index of the array
@@ -19,7 +18,7 @@ async function run() {
     const slotBN = arrayDefinitionBN.add(indexBN);
     const slot = `0x${slotBN.toString("hex")}`
 
-    const fetcher = new OptimismExtractoorClient(process.env.OPTIMISM_GOERLI_RPC_URL || "", process.env.GOERLI_RPC_URL || "");
+    const fetcher = new OptimismExtractoorClient(process.env.OPTIMISM_GOERLI_RPC_URL || "", process.env.GOERLI_RPC_URL || "", OPTIMISM_GOERLI_CONFIG);
 
     // For informational purposes
     const l1Block = await fetcher.ethereum.getBlockByNumber(`0x${blockNum.toString(16)}`);

--- a/example/get-optimism-output-root-data.ts
+++ b/example/get-optimism-output-root-data.ts
@@ -1,12 +1,11 @@
 import { bufferToHex } from 'ethereumjs-util'
-import { MPTProofVerifier } from 'extractoor'
-import { OptimismExtractoorClient } from 'extractoor'
+import { MPTProofVerifier, OptimismExtractoorClient, OPTIMISM_GOERLI_CONFIG } from './../src'
 const dotenv = require('dotenv');
 dotenv.config()
 
 async function run() {
     const blockNum = 8525295;
-    const fetcher = new OptimismExtractoorClient(process.env.OPTIMISM_GOERLI_RPC_URL || "", process.env.GOERLI_RPC_URL || "");
+    const fetcher = new OptimismExtractoorClient(process.env.OPTIMISM_GOERLI_RPC_URL || "", process.env.GOERLI_RPC_URL || "", OPTIMISM_GOERLI_CONFIG);
 
     const output = await fetcher.generateLatestOutputData(`0x${blockNum.toString(16)}`);
 

--- a/example/rlp-encode-proofs.ts
+++ b/example/rlp-encode-proofs.ts
@@ -1,5 +1,5 @@
 import { bufferToHex } from 'ethereumjs-util'
-import { MPTProofVerifier, MPTProofsEncoder } from 'extractoor'
+import { MPTProofVerifier, MPTProofsEncoder } from './../src'
 
 
 async function run() {

--- a/example/verify-ethereum-proofs.ts
+++ b/example/verify-ethereum-proofs.ts
@@ -1,5 +1,5 @@
 import { bufferToHex } from 'ethereumjs-util'
-import { MPTProofVerifier } from 'extractoor'
+import { MPTProofVerifier } from './../src'
 
 
 async function run() {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.2",
+  "version": "0.1.3",
   "license": "MIT",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/src/networks/optimism/OptimismExtractoorClient.ts
+++ b/src/networks/optimism/OptimismExtractoorClient.ts
@@ -14,7 +14,7 @@ export const OPTIMISM_GOERLI_CONFIG: OptimismNetworkConfig = {
 
 export const BASE_GOERLI_CONFIG: OptimismNetworkConfig = {
     L2WithdrawalContractAddress: "0x4200000000000000000000000000000000000016",
-    OutputOracleAddress: "0xE6Dfba0953616Bacab0c9A8ecb3a9BBa77FC15c0",
+    OutputOracleAddress: "0x2A35891ff30313CcFa6CE88dcf3858bb075A2298",
     OutputOracleL2OutputPosition: 3
 }
 

--- a/src/networks/optimism/OptimismExtractoorClient.ts
+++ b/src/networks/optimism/OptimismExtractoorClient.ts
@@ -6,19 +6,34 @@ import { OutputOracleABICoder } from "../../utils/optimism/OutputOracleABICoder"
 import { MPTProofVerifier } from "../../verifier/MPTProofVerifier";
 import { EthereumExtractoorClient } from "../ethereum/EthereumExtractoorClient";
 
-// GOERLI
-const OutputOracleAddress = "0xE6Dfba0953616Bacab0c9A8ecb3a9BBa77FC15c0";
-const L2WithdrawalContractAddress = "0x4200000000000000000000000000000000000016";
-const OutputOracleL2OutputPosition = 3;
+export const OPTIMISM_GOERLI_CONFIG: OptimismNetworkConfig = {
+    L2WithdrawalContractAddress: "0x4200000000000000000000000000000000000016",
+    OutputOracleAddress: "0xE6Dfba0953616Bacab0c9A8ecb3a9BBa77FC15c0",
+    OutputOracleL2OutputPosition: 3
+}
+
+export const BASE_GOERLI_CONFIG: OptimismNetworkConfig = {
+    L2WithdrawalContractAddress: "0x4200000000000000000000000000000000000016",
+    OutputOracleAddress: "0xE6Dfba0953616Bacab0c9A8ecb3a9BBa77FC15c0",
+    OutputOracleL2OutputPosition: 3
+}
+
+export interface OptimismNetworkConfig {
+    L2WithdrawalContractAddress: string,
+    OutputOracleAddress: string,
+    OutputOracleL2OutputPosition: number
+}
 
 export class OptimismExtractoorClient {
 
     optimism: EthereumExtractoorClient
     ethereum: EthereumExtractoorClient
+    networkConfig: OptimismNetworkConfig
 
-    constructor(optimismRpcUrl: string, ethereumRpcUrl: string) {
+    constructor(optimismRpcUrl: string, ethereumRpcUrl: string, networkConfig: OptimismNetworkConfig) {
         this.optimism = new EthereumExtractoorClient(optimismRpcUrl);
         this.ethereum = new EthereumExtractoorClient(ethereumRpcUrl)
+        this.networkConfig = networkConfig;
     }
 
     async requestEthereum(method: string, params: any[]): Promise<any> {
@@ -36,17 +51,17 @@ export class OptimismExtractoorClient {
 
         // STEP 1 Get from the L1 Bedrock OutputOracle latest block number via latestBlockNumber view function - B.
         const latestBlockNumberCalldata = OutputOracleABICoder.latestBlockNumber();
-        const BHex = await this.ethereum.ethCall(L1Block.number, OutputOracleAddress, latestBlockNumberCalldata)
+        const BHex = await this.ethereum.ethCall(L1Block.number, this.networkConfig.OutputOracleAddress, latestBlockNumberCalldata)
         const B = bufferToInt(toBuffer(BHex));
 
         // STEP 2 Get from the L1 Bedrock OutputOracle the L2 Output index for B via getL2OutputIndexAfter - I
         const getL2OutputIndexAfterCalldata = OutputOracleABICoder.getL2OutputIndexAfter(B);
-        const IHex = await this.ethereum.ethCall(L1Block.number, OutputOracleAddress, getL2OutputIndexAfterCalldata);
+        const IHex = await this.ethereum.ethCall(L1Block.number, this.networkConfig.OutputOracleAddress, getL2OutputIndexAfterCalldata);
         const I = bufferToInt(toBuffer(IHex));
 
         // STEP 3 Get from the L1 Bedrock OutputOracle the L2 Output for block I
         const getL2OutputCalldata = OutputOracleABICoder.getL2Output(I);
-        const l2OutputDataHex = await this.ethereum.ethCall(L1Block.number, OutputOracleAddress, getL2OutputCalldata);
+        const l2OutputDataHex = await this.ethereum.ethCall(L1Block.number, this.networkConfig.OutputOracleAddress, getL2OutputCalldata);
         const contractL2OutputData = OutputOracleABICoder.decodeL2Output(l2OutputDataHex);
 
         if (Number(contractL2OutputData.l2BlockNumber) != B) {
@@ -57,10 +72,10 @@ export class OptimismExtractoorClient {
         const block = await this.optimism.getBlockByNumber(`0x${B.toString(16)}`);
 
         // STEP 5 Get proof from Optimism Rollup node about the withdrawal contract address
-        const withdrawalContractProof = await this.optimism.getProof(L2WithdrawalContractAddress, "0x0", `0x${B.toString(16)}`); // Slot does not matter
+        const withdrawalContractProof = await this.optimism.getProof(this.networkConfig.L2WithdrawalContractAddress, "0x0", `0x${B.toString(16)}`); // Slot does not matter
 
         // STEP 6 Verify the proof against the state root and get account data. Will need it for the storage proof
-        const account = await MPTProofVerifier.verifyAccountProof(block.stateRoot, L2WithdrawalContractAddress, withdrawalContractProof.accountProof);
+        const account = await MPTProofVerifier.verifyAccountProof(block.stateRoot, this.networkConfig.L2WithdrawalContractAddress, withdrawalContractProof.accountProof);
 
         // STEP 7 Calculate locally output root and verify against the one taken in Step 3
         const versionByte = bufferToHex(setLengthLeft(toBuffer(0), 32));
@@ -72,19 +87,19 @@ export class OptimismExtractoorClient {
 
         // STEP 8 Generate the storage slot for the output root contained in the l2Outputs array inside the L1 Bedrock OutputOracle on index I. 
         // Formula is S = ArrayStart+(2*I)
-        const AS = keccak(setLengthLeft(toBuffer(OutputOracleL2OutputPosition), 32));
+        const AS = keccak(setLengthLeft(toBuffer(this.networkConfig.OutputOracleL2OutputPosition), 32));
         const ASBN = new BN(AS);
         const slotOffset = new BN(2 * I);
         const SBN = ASBN.add(slotOffset);
         const S = `0x${SBN.toString("hex")}`
 
         // STEP 9 Get Proof for the storage S from Ethereum.
-        const optimismOutputRootProof = await this.ethereum.getProof(OutputOracleAddress, S, L1Block.number);
+        const optimismOutputRootProof = await this.ethereum.getProof(this.networkConfig.OutputOracleAddress, S, L1Block.number);
         const combinedProof = MPTProofsEncoder.rlpEncodeProofs([optimismOutputRootProof.accountProof, optimismOutputRootProof.storageProof[0].proof]);
 
         const result: OutputData = {
             l1BlockNumber: L1Block.number,
-            l1OutputOracleAddress: OutputOracleAddress,
+            l1OutputOracleAddress: this.networkConfig.OutputOracleAddress,
             version: versionByte,
             optimismStateRoot: bufferToHex(block.stateRoot),
             withdrawalStorageRoot: bufferToHex(account.stateRoot),


### PR DESCRIPTION
Last week, Base was unvailed by Coinbase. Base is built via Optimism Bedrock and extractoor can easily support it out of the box. This PR introduces a new config parameter for the `OptimismExtractoorClient` that allows for the client to know which network to target. Also updates the docs and the readme accordingly.